### PR TITLE
add OpenJDK install instructions for Mac users

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ Allows users to:
 The App can be build and run using gradle, with the following command in the CLI, from the root project directory
 
 `./gradlew clean bootRun`
+
+### Installing JDK on MacOS
+
+If you get a message about a missing JDK, please run `brew install openjdk` and follow the instructions to symlink it ahead of the Mac-default Java in your `PATH`.


### PR DESCRIPTION
I had to do this since I don't do Java development on my Mac, which will likely be true for many visitors to the repo 😁